### PR TITLE
docs(vuepress-docs): migrate to `vuepress-theme-vt`

### DIFF
--- a/packages/vuepress-docs/docs/.vuepress/config.ts
+++ b/packages/vuepress-docs/docs/.vuepress/config.ts
@@ -7,7 +7,7 @@ import {
 } from './config/index'
 
 export = defineConfig(ctx => ({
-  theme: '@vuepress/vue',
+  theme: 'vt',
   dest: '../../vuepress',
   head: [
     ['link', { rel: 'icon', href: `/logo.png` }],
@@ -54,17 +54,21 @@ export = defineConfig(ctx => ({
   themeConfig: {
     repo: 'vuejs/vuepress',
     editLinks: true,
+    logo: '/hero.png',
     docsDir: 'packages/docs/docs',
+
+    // we don't need algolia at VT.
     // #697 Provided by the official algolia team.
-    algolia: ctx.isProd
-      ? {
-        apiKey: '3a539aab83105f01761a137c61004d85',
-        indexName: 'vuepress',
-        algoliaOptions: {
-          facetFilters: ['tags:v1']
-        }
-      }
-      : null,
+    // algolia: ctx.isProd
+    //   ? {
+    //     apiKey: '3a539aab83105f01761a137c61004d85',
+    //     indexName: 'vuepress',
+    //     algoliaOptions: {
+    //       facetFilters: ['tags:v1']
+    //     }
+    //   }
+    //   : null,
+
     smoothScroll: true,
     locales: {
       '/': {

--- a/packages/vuepress-docs/docs/.vuepress/styles/index.styl
+++ b/packages/vuepress-docs/docs/.vuepress/styles/index.styl
@@ -5,6 +5,7 @@
 //}
 
 pre.vue-container
+  background-color: var(--vp-c-bg-soft);
   border-left-width: .5rem;
   border-left-style: solid;
   border-color: #42b983;
@@ -14,10 +15,10 @@ pre.vue-container
     & > p
       margin: -5px 0 -20px 0;
     code
-      background-color: #42b983 !important;
+      background-color: var(--c-brand) !important;
       padding: 3px 5px;
       border-radius: 3px;
-      color #000
+      color #ffffff
     em
       color #808080
       font-weight light

--- a/packages/vuepress-docs/docs/.vuepress/styles/palette.styl
+++ b/packages/vuepress-docs/docs/.vuepress/styles/palette.styl
@@ -1,3 +1,6 @@
-// placeholder for test, dont't remove it.
+:root {
+    --c-brand: #42b883;
+    --c-brand-light: #42d392;
+    --c-brand-dark: #33a06f;
+}
 
-//$accentColor = #f00

--- a/packages/vuepress-docs/docs/guide/markdown.md
+++ b/packages/vuepress-docs/docs/guide/markdown.md
@@ -382,14 +382,14 @@ It also supports [line highlighting](#line-highlighting-in-code-blocks):
 **Input**
 
 ``` md
-<<< @/../@vuepress/markdown/__tests__/fragments/snippet.js{2}
+<<< @/packages/vuepress-docs/docs/.vuepress/enhanceApp.js{2}
 ```
 
 **Output**
 
 <!--lint disable strong-marker-->
 
-<<< @/../@vuepress/markdown/__tests__/fragments/snippet.js{2}
+<!-- <<< @/../@vuepress/markdown/__tests__/fragments/snippet.js{2} -->
 
 <!--lint enable strong-marker-->
 
@@ -409,7 +409,7 @@ You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/co
 
 <!--lint disable strong-marker-->
 
-<<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js
+<!-- <<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js -->
 
 <!--lint enable strong-marker-->
 
@@ -417,7 +417,7 @@ You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/co
 
 <!--lint disable strong-marker-->
 
-<<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet{1}
+<!-- <<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet{1} -->
 
 <!--lint enable strong-marker-->
 

--- a/packages/vuepress-docs/docs/index.md
+++ b/packages/vuepress-docs/docs/index.md
@@ -1,22 +1,21 @@
 ---
 home: true
-heroImage: /hero.png
+# heroImage: /hero.png
+tagline: VuePress is composed of a minimalistic static site generator, and a default theme.
 actionText: Get Started →
 actionLink: /guide/getting-started.html
+subActionText: Introduction
+subActionLink: /guide/
 footer: MIT Licensed | Copyright © 2018-present Evan You
+features:
+  - title: Simplicity First
+    details: Minimal setup with markdown-centered project structure helps you focus on writing.
+  - title: Vue-Powered
+    details: Enjoy the dev experience of Vue + webpack, use Vue components in markdown, and develop custom themes with Vue.
+  - title: Performant
+    details: VuePress generates pre-rendered static HTML for each page, and runs as an SPA once a page is loaded.
 ---
 
-<div class="features">
-  <div class="feature">
-    <h2>Simplicity First</h2>
-    <p>Minimal setup with markdown-centered project structure helps you focus on writing.</p>
-  </div>
-  <div class="feature">
-    <h2>Vue-Powered</h2>
-    <p>Enjoy the dev experience of Vue + webpack, use Vue components in markdown, and develop custom themes with Vue.</p>
-  </div>
-  <div class="feature">
-    <h2>Performant</h2>
-    <p>VuePress generates pre-rendered static HTML for each page, and runs as an SPA once a page is loaded.</p>
-  </div>
-</div>
+::: slot heroText
+Minimalistic <span class="gradient">Vue-powered</span> <br/> static site generator
+:::

--- a/packages/vuepress-docs/docs/zh/README.md
+++ b/packages/vuepress-docs/docs/zh/README.md
@@ -1,8 +1,9 @@
 ---
 home: true
-heroImage: /hero.png
 actionText: 快速上手 →
-actionLink: /zh/guide/
+actionLink: /zh/guide/getting-started.html
+subActionText: 介绍
+subActionLink: /zh/guide/
 features:
 - title: 简洁至上
   details: 以 Markdown 为中心的项目结构，以最少的配置帮助你专注于写作。
@@ -13,22 +14,6 @@ features:
 footer: MIT Licensed | Copyright © 2018-present Evan You
 ---
 
-### 像数 1, 2, 3 一样容易
-
-``` bash
-# 安装
-yarn global add vuepress # 或者：npm install -g vuepress
-
-# 新建一个 markdown 文件
-echo '# Hello VuePress!' > README.md
-
-# 开始写作
-vuepress dev .
-
-# 构建静态文件
-vuepress build .
-```
-
-::: warning 注意
-请确保你的 Node.js 版本 >= 8.6。
+::: slot heroText
+Minimalistic <span class="gradient">Vue-powered</span> <br/> static site generator
 :::

--- a/packages/vuepress-docs/docs/zh/guide/markdown.md
+++ b/packages/vuepress-docs/docs/zh/guide/markdown.md
@@ -384,7 +384,7 @@ module.exports = {
 
 <!--lint disable strong-marker-->
 
-<<< @/../@vuepress/markdown/__tests__/fragments/snippet.js{2}
+<!-- <<< @/../@vuepress/markdown/__tests__/fragments/snippet.js{2} -->
 
 <!--lint enable strong-marker-->
 
@@ -405,7 +405,7 @@ module.exports = {
 
 <!--lint disable strong-marker-->
 
-<<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js
+<!-- <<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js -->
 
 <!--lint enable strong-marker-->
 
@@ -413,7 +413,7 @@ module.exports = {
 
 <!--lint disable strong-marker-->
 
-<<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet{1}
+<!-- <<< @/../@vuepress/markdown/__tests__/fragments/snippet-with-region.js#snippet{1} -->
 
 <!--lint enable strong-marker-->
 

--- a/packages/vuepress-docs/package.json
+++ b/packages/vuepress-docs/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "vuepress": "1.9.5",
+    "vuepress-theme-vt": "0.1.4",
     "@vuepress/plugin-back-to-top": "1.9.5",
     "@vuepress/plugin-google-analytics": "1.9.5",
     "@vuepress/plugin-medium-zoom": "1.9.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ importers:
       vue-toasted: ^1.1.25
       vuepress: 1.9.5
       vuepress-plugin-flowchart: ^1.4.2
+      vuepress-theme-vt: 0.1.4
     devDependencies:
       '@vuepress/plugin-back-to-top': 1.9.5
       '@vuepress/plugin-google-analytics': 1.9.5
@@ -76,6 +77,7 @@ importers:
       vue-toasted: 1.1.28
       vuepress: 1.9.5
       vuepress-plugin-flowchart: 1.5.0
+      vuepress-theme-vt: link:../vuepress-theme-vt
 
   packages/vuepress-theme-vt:
     specifiers:


### PR DESCRIPTION
# Summary

To verify the [compatibility](https://vuepress-theme-vt.vercel.app/guide/migration.html) of this theme, this pull request migrate VuePress's official documentation to VT with minimal cost.

Preview link: https://vuepress-docs-git-feat-migrate-vuepress-docs-472590061.vercel.app/

