### PR TITLE
fix(theme): header remove 'position: relative'

### DIFF
--- a/packages/vuepress-theme-vt/styles/header.styl
+++ b/packages/vuepress-theme-vt/styles/header.styl
@@ -1,6 +1,5 @@
 .vp-doc {
     h1, h2, h3, h4, h5, h6 {
-        position: relative;
         font-weight: 600;
         line-height: 1.5;
 


### PR DESCRIPTION
## Description of the problem: 
When using `position: relative` in the header, the link in the previous line is blocked and cannot be clicked.

## Demo

### use `position: relative`

```html
<a href="www.baidu.com">baidu</a>
<h2 className='h2' >header use relative</h2>
```

```css
.h2 {
    color: #213547;
    box-sizing: border-box;
    position: relative; /* <- this line */
    margin: 3rem 0 1.25rem;
}

.h2:hover {
  background-color: red;
}

h2::before {
  display: block;
  content: ' ';
  height: 70px;
  margin-top: -70px;
}
```
![use](https://user-images.githubusercontent.com/24872439/150781405-91f41198-c5db-4b1b-87f7-063d8a760cce.gif)

### not use `position: relative`

```html
<a href="www.baidu.com">baidu</a>
<h2 className='h2' >header not use relative</h2>
```

```css
.h2 {
    color: #213547;
    box-sizing: border-box;
    /* position: relative;   <- this line */
    margin: 3rem 0 1.25rem;
}

.h2:hover {
  background-color: red;
}

h2::before {
  display: block;
  content: ' ';
  height: 70px;
  margin-top: -70px;
}
```

![not](https://user-images.githubusercontent.com/24872439/150781677-e47bd4f1-064e-4b93-b0ef-43e04fe0593a.gif)

