### PR TITLE
fix(vuepress-theme-vt): remove overflow-x to fix dropdown

### DIFF
--- a/packages/vuepress-theme-vt/components/NavLinks.vue
+++ b/packages/vuepress-theme-vt/components/NavLinks.vue
@@ -128,7 +128,6 @@ export default {
 .nav-links {
   display: inline-block;
   max-width: calc(100vw - 260px);
-  overflow-x: scroll;
 
   a {
     line-height: 1.4rem;


### PR DESCRIPTION
Closes #43 
temporarily remove `overflow-x: scroll` to show Dropdown.