### PR TITLE
fix(theme): code highlighting is hard to read (close: #57)

### DIFF
--- a/packages/docs/docs/guide/documenting.md
+++ b/packages/docs/docs/guide/documenting.md
@@ -251,3 +251,20 @@ Detail
 <Badge text="TIP"/>
 <Badge text="WARNING" type="warning"/>
 <Badge text="ERROR" type="error"/>
+
+
+## Code Highlighting
+
+```sh{4}
+  asset-demo
+  |- package.json
+  |- package-lock.json
+  |- speedy.config.ts
+  |- /dist
+    |- bundle.js
+    |- index.html
+  |- /src
++   |- style.css
+    |- index.js
+  |- /node_modules
+```

--- a/packages/vuepress-theme-vt/styles/code-dark.styl
+++ b/packages/vuepress-theme-vt/styles/code-dark.styl
@@ -20,7 +20,6 @@
     }
 
     code, code[class*='language-'], pre[class*='language-'] {
-        background-color: var(--vp-c-bg-soft);
         color: #a6accd;
         font-family: 'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
         direction: ltr;
@@ -28,7 +27,6 @@
         white-space: pre;
         word-spacing: normal;
         word-break: normal;
-        line-height: 1.5;
         -moz-tab-size: 2;
         -o-tab-size: 2;
         tab-size: 2;

--- a/packages/vuepress-theme-vt/styles/code.styl
+++ b/packages/vuepress-theme-vt/styles/code.styl
@@ -61,7 +61,7 @@ div[class*='language-'] {
     line-height: 1.4;
 
     .highlighted {
-      background-color: rgba(0, 0, 0, 66%);
+      background-color: var(--vp-c-bg-code-highlight)
     }
   }
 

--- a/packages/vuepress-theme-vt/styles/theme.styl
+++ b/packages/vuepress-theme-vt/styles/theme.styl
@@ -20,6 +20,8 @@
     --vp-c-gray-dark-3: #3a3a3a;
     --vp-c-gray-dark-4: #282828;
     --vp-c-gray-dark-5: #202020;
+    --vp-c-gray-dark-6: #ebebeb;
+    --vp-c-gray-dark-7: #000000;
     --vp-c-divider-light-1: rgba(60, 60, 60, 0.29);
     --vp-c-divider-light-2: rgba(60, 60, 60, 0.12);
     --vp-c-divider-dark-1: rgba(84, 84, 84, 0.65);
@@ -71,6 +73,7 @@
     --vp-c-bg: var(--vp-c-white);
     --vp-c-bg-soft: var(--vp-c-white-soft);
     --vp-c-bg-mute: var(--vp-c-white-mute);
+    --vp-c-bg-code-highlight: var(--vp-c-gray-dark-6);
     --vp-c-divider: var(--vp-c-divider-light-1);
     --vp-c-divider-light: var(--vp-c-divider-light-2);
     --vp-c-divider-inverse: var(--vp-c-divider-dark-1);
@@ -95,6 +98,7 @@
     --vp-c-bg: var(--vp-c-black);
     --vp-c-bg-soft: var(--vp-c-black-soft);
     --vp-c-bg-mute: var(--vp-c-black-mute);
+    --vp-c-bg-code-highlight: var(--vp-c-gray-dark-7);
     --vp-c-divider: var(--vp-c-divider-dark-1);
     --vp-c-divider-light: var(--vp-c-divider-dark-2);
     --vp-c-divider-inverse: var(--vp-c-divider-light-1);


### PR DESCRIPTION
# Snapshot

## Light

![image](https://user-images.githubusercontent.com/23133919/157078360-5c0cc521-bcc8-45fe-b018-c343399f7140.png)


## Dark

![image](https://user-images.githubusercontent.com/23133919/157078478-651027fd-e865-4a5f-a207-6f75418d6dab.png)

