### PR TITLE
feat: support custom extracted headers in api page

### DIFF
--- a/packages/docs/docs/api/config-frontmatter.md
+++ b/packages/docs/docs/api/config-frontmatter.md
@@ -62,7 +62,6 @@ sidebar: false
 
 See [live example](../../../docs/docs/examples/disable-sidebar.md).
 
-
 ## sidebarDepth
 
 - **Type**: `number`
@@ -94,5 +93,18 @@ Display page edit at the bottom, set `false` to hidden it:
 ```md
 ---
 pageEdit: false
+---
+```
+
+## extractApiHeaders
+
+- **Type**: `number[]`
+- **Default**: [2, 3]
+
+Extract headers of target levels from api page, by default it will extract `h2` and `h3` headers:
+
+```md
+---
+extractApiHeaders: [2]
 ---
 ```

--- a/packages/vuepress-theme-vt/components/API.vue
+++ b/packages/vuepress-theme-vt/components/API.vue
@@ -25,10 +25,10 @@ export default {
                 text: group.title,
                 description: group.description,
                 items: group.children.map((item) => {
-                  const { extractApiHeaders = [2, 3] } = page.frontmatter;
                   const page = this.$site.pages.find(
                     (page) => page.regularPath === item + ".html"
                   );
+                  const { extractApiHeaders = [2, 3] } = page.frontmatter;
                   return {
                     pageClass: page.frontmatter && page.frontmatter.pageClass,
                     text: page.title,

--- a/packages/vuepress-theme-vt/components/API.vue
+++ b/packages/vuepress-theme-vt/components/API.vue
@@ -25,6 +25,7 @@ export default {
                 text: group.title,
                 description: group.description,
                 items: group.children.map((item) => {
+                  const { extractApiHeaders = [2, 3] } = page.frontmatter;
                   const page = this.$site.pages.find(
                     (page) => page.regularPath === item + ".html"
                   );
@@ -32,8 +33,8 @@ export default {
                     pageClass: page.frontmatter && page.frontmatter.pageClass,
                     text: page.title,
                     link: page.path,
-                    headers: (page.headers || []).filter(
-                      (header) => header.level === 2 || header.level === 3
+                    headers: (page.headers || []).filter((header) =>
+                      extractApiHeaders.includes(header.level)
                     ),
                   };
                 }),


### PR DESCRIPTION
Currently in api page, vt will extract all h2 and h3 headers by default.But sometimes we don't want the h3 header and there is no custom config.The pr is to solve the problem.