### PR TITLE
fix(theme): wrong sidebar layout when status is enabled (close: #67)

### DIFF
--- a/packages/vuepress-theme-vt/components/Navbar.vue
+++ b/packages/vuepress-theme-vt/components/Navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="navbar" :class="{'navbar-down': shouldShowStatusBar}">
+  <header class="navbar">
     <div class="navbar-container">
       <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')" />
 
@@ -57,8 +57,6 @@ export default {
     SearchBox,
     AlgoliaSearchBox,
   },
-
-  props:['shouldShowStatusBar'],
 
   data() {
     return {
@@ -194,8 +192,4 @@ function css(el, property) {
   }
 }
 
-.navbar-down{
-  top: var(--vp-statusbar-height);
-  border-top: 1px solid var(--vp-c-divider-light);
-}
 </style>

--- a/packages/vuepress-theme-vt/layouts/Layout.vue
+++ b/packages/vuepress-theme-vt/layouts/Layout.vue
@@ -11,7 +11,6 @@
 
     <Navbar
       v-if="shouldShowNavbar"
-      :shouldShowStatusBar="shouldShowStatusBar"
       @toggle-sidebar="toggleSidebar"
     />
 
@@ -155,7 +154,8 @@ export default {
         {
           'no-navbar': !this.shouldShowNavbar,
           'sidebar-open': this.isSidebarOpen,
-          'no-sidebar': !this.shouldShowSidebar
+          'no-sidebar': !this.shouldShowSidebar,
+          'statusbar-enabled': this.shouldShowStatusBar,
         },
         userPageClass
       ]
@@ -214,3 +214,15 @@ export default {
   },
 };
 </script>
+
+<style lang="stylus">
+.theme-container.statusbar-enabled {
+  .navbar {
+    top: var(--vp-statusbar-height);
+    border-top: 1px solid var(--vp-c-divider-light);
+  }
+  .sidebar {
+    top: calc(var(--vp-navbar-height) + var(--vp-statusbar-height));
+  }
+}
+</style>

--- a/packages/vuepress-theme-vt/styles/theme.styl
+++ b/packages/vuepress-theme-vt/styles/theme.styl
@@ -117,7 +117,7 @@
 }
 
 :root {
-    --vp-navbar-height: 5rem;
+    --vp-navbar-height: 3.6rem;
     --vp-statusbar-height: 2rem;
     --vp-sidebar-width: 15vw;
     --vp-toc-width: 16vw;


### PR DESCRIPTION
# Snapshot

## Before

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/23133919/198929294-069bf828-34b6-4b54-9a2b-19cddc8a215c.png">


## After

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/23133919/198929247-19fcbe8e-db44-4151-b4df-59b6b2516ddd.png">
