### PR TITLE
feat(theme): nav links on the left (close: 73)

### DIFF
--- a/packages/docs/docs/.vuepress/config.ts
+++ b/packages/docs/docs/.vuepress/config.ts
@@ -11,6 +11,11 @@ export default defineConfig4CustomTheme<ThemeConfig>((ctx) => ({
     nav: [
       { text: "Guide", link: "/guide/" },
       { text: "API", link: "/api/" },
+      { 
+        text: "Nav Links on the left", 
+        link: "/guide/navbar.html#nav-links-on-the-left",
+        position: "left"
+      },
     ],
     sidebar: {
       "/guide/": [
@@ -33,6 +38,7 @@ export default defineConfig4CustomTheme<ThemeConfig>((ctx) => ({
             "/guide/page-layout",
             "/guide/code-switcher",
             "/guide/status",
+            "/guide/navbar",
             "/guide/documenting",
           ],
         },

--- a/packages/docs/docs/guide/navbar.md
+++ b/packages/docs/docs/guide/navbar.md
@@ -1,0 +1,44 @@
+# Navbar
+
+## Motivation
+
+Same to [VuePress Default Theme](https://vuepress.vuejs.org/theme/default-theme-config.html), The Navbar may contain your page title, [Search Box](https://vuepress.vuejs.org/theme/default-theme-config.html#search-box), [Navbar Links](https://vuepress.vuejs.org/theme/default-theme-config.html#navbar-links), [Languages](https://vuepress.vuejs.org/guide/i18n.html) and [Repository Link](https://vuepress.vuejs.org/theme/default-theme-config.html#git-repository-and-edit-links), they all depend on your configuration.
+
+VT introduced some extra Navbar features.
+
+## Nav Links on the left <Badge text="0.6.0+"/>
+
+In [VuePress Default Theme](https://vuepress.vuejs.org/theme/default-theme-config.html), you can add links to the navbar via `themeConfig.nav`:
+
+```ts
+// .vuepress/config.js
+module.exports = {
+  themeConfig: {
+    nav: [
+      { text: "Guide", link: "/guide/" },
+      { text: "API", link: "/api/" },
+    ],
+  },
+};
+```
+
+These links display on the right by default, you can change them into the right via additional `position` config:
+
+```ts{10}
+// .vuepress/config.js
+module.exports = {
+  themeConfig: {
+    nav: [
+      { text: "Guide", link: "/guide/" },
+      { text: "API", link: "/api/" },
+      {
+        text: "Nav Links on the left",
+        link: "/guide/navbar.html#nav-links-on-the-left",
+        position: "left",
+      },
+    ],
+  },
+};
+```
+
+The effect is shown on this site.

--- a/packages/vuepress-theme-vt/components/Navbar.vue
+++ b/packages/vuepress-theme-vt/components/Navbar.vue
@@ -19,32 +19,12 @@
         >
       </RouterLink>
 
-      <div
-        class="links"
-        :style="
-          linksWrapMaxWidth
-            ? {
-                'max-width': linksWrapMaxWidth + 'px',
-              }
-            : {}
-        "
-      >
-        <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
-        <SearchBox
-          v-else-if="
-            $site.themeConfig.search !== false &&
-            $page.frontmatter.search !== false
-          "
-        />
-        <NavLinks class="can-hide" />
-      </div>
+      <NavLinks class="can-hide" />
     </div>
   </header>
 </template>
 
 <script>
-import AlgoliaSearchBox from "@AlgoliaSearchBox";
-import SearchBox from "@SearchBox";
 import SidebarButton from "@theme/components/SidebarButton.vue";
 import NavLinks from "@theme/components/NavLinks.vue";
 
@@ -54,54 +34,8 @@ export default {
   components: {
     SidebarButton,
     NavLinks,
-    SearchBox,
-    AlgoliaSearchBox,
-  },
-
-  data() {
-    return {
-      linksWrapMaxWidth: null,
-    };
-  },
-
-  computed: {
-    algolia() {
-      return (
-        this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {}
-      );
-    },
-
-    isAlgoliaSearch() {
-      return this.algolia && this.algolia.apiKey && this.algolia.indexName;
-    },
-  },
-
-  mounted() {
-    const MOBILE_DESKTOP_BREAKPOINT = 719; // refer to config.styl
-    const NAVBAR_VERTICAL_PADDING =
-      parseInt(css(this.$el, "paddingLeft")) +
-      parseInt(css(this.$el, "paddingRight"));
-    const handleLinksWrapWidth = () => {
-      if (document.documentElement.clientWidth < MOBILE_DESKTOP_BREAKPOINT) {
-        this.linksWrapMaxWidth = null;
-      } else {
-        this.linksWrapMaxWidth =
-          this.$el.offsetWidth -
-          NAVBAR_VERTICAL_PADDING -
-          ((this.$refs.siteName && this.$refs.siteName.offsetWidth) || 0);
-      }
-    };
-    handleLinksWrapWidth();
-    window.addEventListener("resize", handleLinksWrapWidth, false);
   },
 };
-
-function css(el, property) {
-  // NOTE: Known bug, will return 'auto' if style value is 'auto'
-  const win = el.ownerDocument.defaultView;
-  // null means not to return pseudo styles
-  return win.getComputedStyle(el, null)[property];
-}
 </script>
 
 <style lang="stylus">
@@ -151,22 +85,6 @@ function css(el, property) {
     position: relative;
   }
 
-  .links {
-    height: 100%;
-    padding-left: 1.5rem;
-    box-sizing: border-box;
-    white-space: nowrap;
-    font-size: 13px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    flex: 1;
-
-    .search-box {
-      flex: 0 0 auto;
-      vertical-align: top;
-    }
-  }
 }
 
 @media (max-width: $MQMobile) {
@@ -177,10 +95,6 @@ function css(el, property) {
 
     .can-hide {
       display: none;
-    }
-
-    .links {
-      padding-left: 1.5rem;
     }
 
     .site-name {

--- a/packages/vuepress-theme-vt/components/Sidebar.vue
+++ b/packages/vuepress-theme-vt/components/Sidebar.vue
@@ -1,6 +1,6 @@
 <template>
   <aside class="sidebar">
-    <NavLinks />
+    <NavLinks :showSearchBox="false"/>
 
     <slot name="top" />
 
@@ -34,7 +34,7 @@ export default {
     display: inline-block;
   }
 
-  .nav-links {
+  .links {
     display: none;
     border-bottom: 1px solid var(--vp-c-divider-light);
     padding: 0.5rem 0 0.75rem 0;
@@ -71,8 +71,9 @@ export default {
   .sidebar {
     padding-left: 1rem;
 
-    .nav-links {
+    .links {
       display: block;
+      padding-left: 0;
 
       .dropdown-wrapper .nav-dropdown .dropdown-item a.router-link-active::after {
         top: calc(1rem - 2px);

--- a/packages/vuepress-theme-vt/src/types.ts
+++ b/packages/vuepress-theme-vt/src/types.ts
@@ -1,8 +1,22 @@
 /** @format */
 
-import type { DefaultThemeConfig } from "@vuepress/types";
+import type { DefaultThemeConfig, NavItem } from "@vuepress/types";
 
-export type ThemeConfig = DefaultThemeConfig & {
+export type EnhancedNavItem = NavItem & {
+  /**
+   * Specify the position of navbar item.
+   * 
+   * @default "right"
+   */
+  position?: "left" | "right";
+};
+
+export type ThemeConfig = Omit<DefaultThemeConfig, "nav"> & {
+  /**
+   * Navbar Links.
+   */
+  nav: EnhancedNavItem[];
+
   /**
    * Text in status bar
    */
@@ -24,7 +38,7 @@ export type ThemeConfig = DefaultThemeConfig & {
   transformTranslatedDocument?: (
     content: string,
     sourceFile: string,
-    targetFile: string,
+    targetFile: string
   ) => string;
   /**
    * Options for code switcher.

--- a/packages/vuepress-theme-vt/styles/config.styl
+++ b/packages/vuepress-theme-vt/styles/config.styl
@@ -1,5 +1,5 @@
 $contentClass = '.theme-default-content';
-$navbarHeight = 3rem
+$navbarHeight = 3.6rem
 
 /**
  * CSS Varible cannot be used at media query, so we used stylus varaible here.

--- a/packages/vuepress-theme-vt/styles/index.styl
+++ b/packages/vuepress-theme-vt/styles/index.styl
@@ -7,7 +7,6 @@
 @require './wrapper';
 @require './toc';
 @require './header';
-@require './mobile';
 @require './home';
 @require './vp-doc';
 
@@ -235,3 +234,5 @@ table {
     }
   }
 }
+
+@require './mobile';


### PR DESCRIPTION
# Snapshot

## Config

```ts
export default {
  theme: "vt",
  themeConfig: {
    nav: [
      { text: "Guide", link: "/guide/" },
      { text: "API", link: "/api/" },
      { text: "Left1", link: "/guide/api-page", position: "left" },
      { text: "Left2", link: "/guide/configuration", position: "left" },
    ],
  },
};
```

## Desktop

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/23133919/198978737-0a5b3118-329c-4d84-85da-371488b4c227.png">


## Mobile

<img width="686" alt="image" src="https://user-images.githubusercontent.com/23133919/198978832-ae4bd88e-67c7-4792-8711-232573db8419.png">

