### PR TITLE
feat: using Vue component to define status

### DIFF
--- a/packages/docs/docs/.vuepress/components/GlobalStatus.vue
+++ b/packages/docs/docs/.vuepress/components/GlobalStatus.vue
@@ -1,0 +1,3 @@
+<template>
+  <span> This is page status </span>
+</template>

--- a/packages/docs/docs/guide/status.md
+++ b/packages/docs/docs/guide/status.md
@@ -1,5 +1,5 @@
 ---
-status: $status
+status: <GlobalStatus />
 ---
 
 # Status
@@ -31,22 +31,32 @@ status: 'This is page status'
 ---
 ```
 
-## Rich-text page status
+## Using Vue Component
 
-You can specify rich-text page status via [markdown slot](https://vuepress.vuejs.org/guide/markdown-slot.html).
+You can specify page status via a global Vue Component, let's create `.vuepress/components/GlobalStatus.vue` as example:
+  
+```vue
+<template>
+  <span> This is page status </span>
+</template>
+```
 
-Note that you'll need declare [frontmatter.status](https://vuepress.vuejs.org/guide/frontmatter.html) to `$variable` to tell VT to leverage corresponding slot:
+- via page frontmatter config:
 
 ```md
 ---
-status: $status
+status: <GlobalStatus />
 ---
-
-::: status
-THIS IS PAGE STATUS, [JUMP TO HOME PAGE](/)
-:::
 ```
 
-::: slot status
-THIS IS PAGE STATUS, [JUMP TO HOME PAGE](/)
-:::
+- via global config:
+
+```ts
+// .vuepress/config.js
+module.exports = {
+  theme: "vt",
+  themeConfig: {
+    status: '<GlobalStatus />'
+  },
+};
+```

--- a/packages/vuepress-theme-vt/components/StatusBar.vue
+++ b/packages/vuepress-theme-vt/components/StatusBar.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="statusbar">
-    <Content v-if="statusText.startsWith('$')" :slot-key="statusText.slice(1)" />
+    <component
+      v-if="status.type === 'component'"
+      :is="status.value"
+    ></component>
     <span v-else>
-      {{ statusText }}
+      {{ status.value }}
     </span>
   </div>
 </template>
@@ -11,14 +14,7 @@
 export default {
   name: "StatusBar",
 
-  computed: {
-    statusText() {
-      return (
-        (this.$frontmatter && this.$frontmatter.status) ||
-        this.$themeLocaleConfig.status
-      );
-    },
-  },
+  props: ['status']
 };
 </script>
 

--- a/packages/vuepress-theme-vt/src/types.ts
+++ b/packages/vuepress-theme-vt/src/types.ts
@@ -23,7 +23,7 @@ export type ThemeConfig = Omit<DefaultThemeConfig, "nav" | "locales"> & {
   nav?: EnhancedNavItem[];
 
   /**
-   * Text in status bar
+   * Status config, a plain text or a Vue component declaration ("e.g. <MyStatus />")
    */
   status?: string;
 


### PR DESCRIPTION
# Summary


You can specify page status via a global Vue Component, let's create `.vuepress/components/GlobalStatus.vue` as example:
  
```vue
<template>
  <span> This is page status </span>
</template>
```

- via page frontmatter config:

```md
---
status: <GlobalStatus />
---
```

- via global config:

```ts
// .vuepress/config.js
module.exports = {
  theme: "vt",
  themeConfig: {
    status: '<GlobalStatus />'
  },
};
```

