### PR TITLE
fix: header anchor cannot position correctly when status is enabled

### DIFF
--- a/packages/vuepress-theme-vt/styles/header.styl
+++ b/packages/vuepress-theme-vt/styles/header.styl
@@ -69,3 +69,14 @@
         transition: color 0.25s, opacity 0.25s;
     }
 }
+
+.theme-container.statusbar-enabled {
+    .vp-doc {
+        h1, h2, h3, h4, h5, h6 {
+            &::before {
+                margin-top: calc(-1 * (var(--vp-statusbar-height) + 72px));
+                height: calc(var(--vp-statusbar-height) + 72px);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

When you clicked the header anchor,  is missing when status is enabled.

<img width="944" alt="image" src="https://user-images.githubusercontent.com/23133919/223887791-da691c4c-efb0-4549-ba24-f1f16fd4703b.png">


<img width="969" alt="image" src="https://user-images.githubusercontent.com/23133919/223887666-2fb4ee61-53bf-4847-bc4e-4bbbb0370320.png">
